### PR TITLE
Add Code Canvas page

### DIFF
--- a/src/app/tools/code-canvas/page.tsx
+++ b/src/app/tools/code-canvas/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+const defaultCode = `function App() {
+  const [count, setCount] = React.useState(0)
+  return (
+    <div style={{ fontFamily: 'sans-serif' }}>
+      <h1>Hello Code Canvas!</h1>
+      <button onClick={() => setCount(count + 1)}>
+        Count: {count}
+      </button>
+    </div>
+  )
+}
+`
+
+export default function CodeCanvasPage() {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [code, setCode] = useState(defaultCode)
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+${code}
+    const rootElement = document.getElementById('root');
+    ReactDOM.createRoot(rootElement).render(<App />);
+  </script>
+</body>
+</html>`
+    iframe.srcdoc = html
+  }, [code])
+
+  return (
+    <main className="prose w-full max-w-3xl my-8 space-y-4 px-8 sm:px-8 lg:px-8">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-4xl font-bold font-heading tracking-tight">Code Canvas</h1>
+        <p className="text-muted-foreground">Execute códigos React em tempo real</p>
+      </div>
+      <textarea
+        className="font-mono border rounded p-2 w-full h-48"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+      />
+      <iframe
+        ref={iframeRef}
+        className="w-full h-96 border rounded bg-white"
+        sandbox="allow-scripts"
+        title="code-canvas"
+      />
+    </main>
+  )
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   KeyRound,
   Scale,
   Settings2,
+  SquareTerminal,
 } from 'lucide-react'
 import {
   Sidebar as SidebarComponent,
@@ -64,6 +65,12 @@ const utilityGroups = [
         description: 'Gerador de Senhas Seguras',
         href: '/tools/password-generator',
         icon: KeyRound,
+      },
+      {
+        title: 'Code Canvas',
+        description: 'Execute códigos React em tempo real',
+        href: '/tools/code-canvas',
+        icon: SquareTerminal,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- add new Code Canvas page with React code runner
- list Code Canvas in the sidebar navigation

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_6842d5b57a808332b7456fa8f85ea32a