### PR TITLE
Fix dynamic header title

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,8 +3,20 @@
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
 import { ThemeToggle } from './theme-togle'
+import { usePathname } from 'next/navigation'
 
 export function Header() {
+  const pathname = usePathname()
+
+  const titles: Record<string, string> = {
+    '/': 'Calculadora de IMC',
+    '/tools/imc-calculator': 'Calculadora de IMC',
+    '/tools/password-generator': 'Gerador de Senhas Seguras',
+    '/tools/tmb-calculator': 'Calculadora de TMB',
+  }
+
+  const title = titles[pathname] ?? 'Utils Reflix'
+
   return (
     <header className="group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
@@ -13,7 +25,7 @@ export function Header() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <h1 className="text-base font-medium">Calculadora de IMC</h1>
+        <h1 className="text-base font-medium">{title}</h1>
         <Separator
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"


### PR DESCRIPTION
## Summary
- make header component show page-specific title

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6842db61b0508332a6e4599a9c474eab